### PR TITLE
fix the entrypoint of docker container to avoid using /bin/sh -c "  ".

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ RUN python ./text_generator/run_generation.py \
     --length=20 \
     --model_name_or_path=flaubert-base-cased \
     --temperature=0.1 --repetition_penalty=20 --num_return_sequences=1 --prompt a
-ENTRYPOINT python -m text_generator.cli
+
+ENTRYPOINT ["python", "-m", "text_generator.cli"]


### PR DESCRIPTION
when you are running inspect command on docker image

```bash
docker inspect sofiacalcagno/delirium
```
you get in entrypoint this implementation

```text
"Entrypoint": [
        "/bin/sh",
        "-c",
        "python -m text_generator.cli"
],
```
The argument management with /bin/sh seems to be the problem. I have changed the implementation to avoid docker to call shell interpreter. Basicaly, I have used the [`exec` form of entrypoint](https://docs.docker.com/engine/reference/builder/#exec-form-entrypoint-example). It's a better practice when you are invoking external program.

The entrypoint in `docker inspect` will be :

```text
"Entrypoint": [
        "python",
        "-m",
        "text_generator.cli"
 ],
```